### PR TITLE
Update instructions to use new createRef API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,15 @@ class BaseSwitch extends React.Component {
 const Switch = withToggle({defaultIsOn: false })(BaseSwitch)
 
 class App extends Component {
+  switchRef = React.createRef()
+
   componentDidMount() {
-    console.log(this.r.getSwitchState()) // on or off
+    console.log(this.switchRef.current.getSwitchState()) // on or off
     console.log(Switch.getSecretNumber()) // 42
   }
 
   render() {
-    return <Switch ref={n => (this.switch = n)} />
+    return <Switch ref={this.switchRef} />
   }
 }
 ```


### PR DESCRIPTION
In Task 1's `App` component,  `this.r` is referenced in `this.r.getSwitchState()`, but is not defined. This line is presumably meant to be  `this.switch.getSwitchState()`.

This has been updated, and also changed to use the new createRef API from React 16.3.